### PR TITLE
Netsuite dynamic host addressing

### DIFF
--- a/netsuite/client.py
+++ b/netsuite/client.py
@@ -136,7 +136,7 @@ class NetSuiteTransport(Transport):
 
 
 class NetSuite:
-    version = '2018.1.0'
+    version = '2019.2.0'
     wsdl_url_tmpl = 'https://{account_id}.suitetalk.api.netsuite.com/wsdl/v{underscored_version}/netsuite.wsdl'
 
     def __repr__(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,16 @@ from setuptools import setup
 
 setup_kwargs = dict(
     name='netsuite',
-    version='0.4.0',
+    version='0.4.1',
     description='Wrapper around Netsuite SuiteTalk Web Services and Restlets',
     packages=['netsuite'],
     include_package_data=True,
     author='Jacob Magnusson',
     author_email='m@jacobian.se',
-    url='https://github.com/jmagnusson/netsuite',
+    fork_author='Stephen Opal'
+    fork_email='sno@merit.edu'
+    fork_org='Merit Network, Inc.'
+    url='https://github.com/merit-netsuite/netsuite',
     license='BSD',
     platforms='any',
     install_requires=[


### PR DESCRIPTION
Problem
---
NetSuite WSDL now relies on dynamic host addresses for accessing subscriber based WSDL documents.  With NetSuite 2020.1, this becomes a requirement, and zeep appears to have a failure to recognize NetSuite's use of relative addressing.

Solution
---
Wrap zeep.transports.transport with a dynamic address manager that updates the get and post services to use subscriber assigned dynamic addressing.
